### PR TITLE
chore: Adds tooling documentation within README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@ Hate reading, here's a video: https://youtu.be/SknFflQVOys!
 
 Love reading, here's blog post: www.netlify.app/blog/deploy-your-astro-project-fast/!
 
+## Table of Contents:
+
+- [⚡️ Quick Setup + Deploy Option](#⚡️-quick-setup--deploy-option)
+- [💫 Regular Setup](#💫-regular-setup)
+  - [Cloning + Install Packages](#1-cloning--install-packages)
+  - [Deploying](#2-deploying)
+- [Astro 💙 Netlify Resources](#astro-💙-netlify-resources)
+- [🚀 Project Structure](#🚀-project-structure)
+- [🧞 Commands](#🧞-commands)
+- [🛠 Testing](#🛠-testing)
+  - [Included Default Testing](#included-default-testing)
+  - [Removing Renovate](#removing-renovate)
+  - [Removing Cypress](#removing-cypress)
+- [👀 Want to learn more?](#👀-want-to-learn-more)
+
 ## ⚡️ Quick Setup + Deploy Option
 
 Click this button and it will help you create a new repo, create a new Netlify project, and deploy!
@@ -91,6 +106,48 @@ All commands are run from the root of the project, from a terminal:
 | `npm run dev`     | Starts local dev server at `localhost:3000`  |
 | `npm run build`   | Build your production site to `./dist/`      |
 | `npm run preview` | Preview your build locally, before deploying |
+
+## 🛠 Testing
+
+### Included Default Testing
+
+We’ve included some tooling that helps us maintain these templates. This template currently uses:
+
+- [Renovate](https://www.mend.io/free-developer-tools/renovate/) - to regularly update our dependencies
+- [Cypress](https://www.cypress.io/) - to run tests against how the template runs in the browser
+- [Cypress Netlify Build Plugin](https://github.com/cypress-io/netlify-plugin-cypress) - to run our tests during our build process
+
+If your team is not interested in this tooling, you can remove them with ease!
+
+### Removing Renovate
+
+In order to keep our project up-to-date with dependencies we use a tool called [Renovate](https://github.com/marketplace/renovate). If you’re not interested in this tooling, delete the `renovate.json` file and commit that onto your main branch.
+
+### Removing Cypress
+
+For our testing, we use [Cypress](https://www.cypress.io/) for end-to-end testing. This makes sure that we can validate that our templates are rendering and displaying as we’d expect. By default, we have Cypress not generate deploy links if our tests don’t pass. If you’d like to keep Cypress and still generate the deploy links, go into your `netlify.toml` and delete the plugin configuration lines:
+
+```diff
+[[plugins]]
+  package = "netlify-plugin-cypress"
+-  [plugins.inputs.postBuild]
+-    enable = true
+-
+-  [plugins.inputs]
+-    enable = false 
+```
+
+If you’d like to remove the `netlify-plugin-cypress` build plugin entirely, you’d need to delete the entire block above instead. And then make sure sure to remove the package from the dependencies using:
+
+```bash
+npm uninstall -D netlify-plugin-cypress
+```
+
+And lastly if you’d like to remove Cypress entirely, delete the entire cypress folder. Then remove the dependency using:
+
+```bash
+npm uninstall cypress
+```
 
 ## 👀 Want to learn more?
 

--- a/README.md
+++ b/README.md
@@ -10,18 +10,18 @@ Love reading, here's blog post: www.netlify.app/blog/deploy-your-astro-project-f
 
 ## Table of Contents:
 
-- [⚡️ Quick Setup + Deploy Option](#⚡️-quick-setup--deploy-option)
-- [💫 Regular Setup](#💫-regular-setup)
+- [⚡️ Quick Setup + Deploy Option](#-quick-setup--deploy-option)
+- [💫 Regular Setup](#-regular-setup)
   - [Cloning + Install Packages](#1-cloning--install-packages)
   - [Deploying](#2-deploying)
-- [Astro 💙 Netlify Resources](#astro-💙-netlify-resources)
-- [🚀 Project Structure](#🚀-project-structure)
-- [🧞 Commands](#🧞-commands)
-- [🛠 Testing](#🛠-testing)
+- [Astro 💙 Netlify Resources](#astro--netlify-resources)
+- [🚀 Project Structure](#-project-structure)
+- [🧞 Commands](#-commands)
+- [🛠 Testing](#-testing)
   - [Included Default Testing](#included-default-testing)
   - [Removing Renovate](#removing-renovate)
   - [Removing Cypress](#removing-cypress)
-- [👀 Want to learn more?](#👀-want-to-learn-more)
+- [👀 Want to learn more?](#-want-to-learn-more)
 
 ## ⚡️ Quick Setup + Deploy Option
 

--- a/README.md
+++ b/README.md
@@ -10,26 +10,26 @@ Love reading, here's blog post: www.netlify.app/blog/deploy-your-astro-project-f
 
 ## Table of Contents:
 
-- [⚡️ Quick Setup + Deploy Option](#-quick-setup--deploy-option)
-- [💫 Regular Setup](#-regular-setup)
+- [Quick Setup + Deploy Option](#quick-setup--deploy-option)
+- [Regular Setup](#regular-setup)
   - [Cloning + Install Packages](#1-cloning--install-packages)
   - [Deploying](#2-deploying)
-- [Astro 💙 Netlify Resources](#astro--netlify-resources)
-- [🚀 Project Structure](#-project-structure)
-- [🧞 Commands](#-commands)
-- [🛠 Testing](#-testing)
+- [Astro + Netlify Resources](#astro--netlify-resources)
+- [Project Structure](#project-structure)
+- [Commands](#commands)
+- [Testing](#testing)
   - [Included Default Testing](#included-default-testing)
   - [Removing Renovate](#removing-renovate)
   - [Removing Cypress](#removing-cypress)
-- [👀 Want to learn more?](#-want-to-learn-more)
+- [Want to learn more?](#want-to-learn-more)
 
-## ⚡️ Quick Setup + Deploy Option
+## Quick Setup + Deploy Option
 
 Click this button and it will help you create a new repo, create a new Netlify project, and deploy!
 
 [![Deploy to Netlify Button](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/netlify-templates/astro-quickstart)
 
-## 💫 Regular Setup
+## Regular Setup
 
  ### 1. Cloning + Install Packages
 
@@ -60,7 +60,7 @@ Click this button and it will help you create a new repo, create a new Netlify p
     
   - If you want to utilize continuous deployment through GitHub webhooks, run the Netlify command `netlify init` to create a new project based on your repo or `netlify link` to connect your repo to an existing project
 
-## Astro 💙 Netlify Resources
+## Astro + Netlify Resources
 
 Here are some resources to help you on your Astro + Netlify coding fun!
 
@@ -74,7 +74,7 @@ Hope this template helps :) Happy coding 👩🏻‍💻!
 
 ---
 
-## 🚀 Project Structure
+## Project Structure
 
 Inside of your Astro project, you'll see the following folders and files:
 
@@ -96,7 +96,7 @@ There's nothing special about `src/components/`, but that's where we like to put
 
 Any static assets, like images, can be placed in the `public/` directory.
 
-## 🧞 Commands
+## Commands
 
 All commands are run from the root of the project, from a terminal:
 
@@ -107,7 +107,7 @@ All commands are run from the root of the project, from a terminal:
 | `npm run build`   | Build your production site to `./dist/`      |
 | `npm run preview` | Preview your build locally, before deploying |
 
-## 🛠 Testing
+## Testing
 
 ### Included Default Testing
 
@@ -149,6 +149,6 @@ And lastly if you’d like to remove Cypress entirely, delete the entire `cypre
 npm uninstall cypress
 ```
 
-## 👀 Want to learn more?
+## Want to learn more?
 
 Feel free to check [our documentation](https://github.com/withastro/astro) or jump into our [Discord server](https://astro.build/chat).

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ If you’d like to remove the `netlify-plugin-cypress` build plugin entirely, 
 npm uninstall -D netlify-plugin-cypress
 ```
 
-And lastly if you’d like to remove Cypress entirely, delete the entire cypress folder. Then remove the dependency using:
+And lastly if you’d like to remove Cypress entirely, delete the entire `cypress` folder and the `cypress.config.ts` file. Then remove the dependency using:
 
 ```bash
 npm uninstall cypress


### PR DESCRIPTION
## Summary

To document our maintenance tooling for others! We want to make sure folks are aware of what we include by default and also how to remove any of it.

### Manual Testing

1. Go over to the `Files changed`
2. Click the breadcrumbs for the README
3. Click on View file
4. Manually test each of the links under the table of contents

![Visual reference for the instructions above ](https://user-images.githubusercontent.com/8431042/172890234-ab2f0ca2-4662-478c-96e4-16d36dbcbb08.png)


### Relevant Issues
- Closes #3 