### PR TITLE
Remove netlify-plugin-cypress from netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,8 +4,6 @@
   functions = "netlify/functions"
   publish = "dist"
 
-[[plugins]] 
-  package = "netlify-plugin-cypress"
 
   [plugins.inputs.postBuild]
     enable = true


### PR DESCRIPTION
Removed the netlify-plugin-cypress from the plugins section.